### PR TITLE
Opening offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pubnative-android-player is an open source IAB VAST 2.0 compilant player for And
 ### Gradle
 
 ```
-compile 'net.pubnative:player:1.0.5'
+compile 'net.pubnative:player:1.0.6'
 ```
 
 <a name="install_manual"></a>

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,6 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-version = 1.0.5
+version = 1.0.6
 group=net.pubnative
 repositoryURL=https://github.com/pubnative/pubnative-android-player

--- a/player/src/main/java/net/pubnative/player/VASTPlayer.java
+++ b/player/src/main/java/net/pubnative/player/VASTPlayer.java
@@ -633,7 +633,7 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
     public void onOpenClick() {
 
         VASTLog.v(TAG, "onOpenClick");
-        stop();
+        pause();
         openOffer();
     }
 
@@ -754,9 +754,11 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
 
     private void showLoader(String message) {
 
-        mLoader.setVisibility(VISIBLE);
-        mLoaderText.setText(message);
-        mLoaderText.setVisibility(TextUtils.isEmpty(message) ? GONE : VISIBLE);
+        if(mPlayerState != PlayerState.Pause) {
+            mLoader.setVisibility(VISIBLE);
+            mLoaderText.setText(message);
+            mLoaderText.setVisibility(TextUtils.isEmpty(message) ? GONE : VISIBLE);
+        }
     }
 
     private void hideLoader() {


### PR DESCRIPTION
This patch includes calling pause rather than stop on offer open.

I changed this behaviour because on some devices with lower version of Android, calling `prepareAsync` after stopping media player was causing problem as `IllegalState` and thus media player was going in `error` state.
