### PR TITLE
Banner display

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pubnative-android-player is an open source IAB VAST 2.0 compilant player for And
 ### Gradle
 
 ```
-compile 'net.pubnative:player:1.0.8'
+compile 'net.pubnative:player:1.0.9'
 ```
 
 <a name="install_manual"></a>

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,6 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-version = 1.0.8
+version = 1.0.9
 group=net.pubnative
 repositoryURL=https://github.com/pubnative/pubnative-android-player

--- a/player/src/main/java/net/pubnative/player/VASTPlayer.java
+++ b/player/src/main/java/net/pubnative/player/VASTPlayer.java
@@ -166,6 +166,7 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
     private PlayerState   mPlayerState      = PlayerState.Empty;
     private List<Integer> mProgressTracker  = null;
     private double        mTargetAspect     = -1.0;
+    private boolean       mIsBannerSet      = false;
 
     public VASTPlayer(Context context) {
         super(context);
@@ -325,6 +326,11 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
         mTrackingEventMap = null;
         mProgressTracker = null;
         mBannerBitmap = null;
+        if (mIsBannerSet) {
+            mIsBannerSet = false;
+        } else {
+            mBannerBitmap = null;
+        }
     }
 
     private void setLoadingState() {
@@ -463,6 +469,7 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
         } else {
             mBanner.setImageBitmap(mBannerBitmap);
         }
+        mIsBannerSet = true;
     }
 
     /**
@@ -634,6 +641,9 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
     public void onOpenClick() {
 
         VASTLog.v(TAG, "onOpenClick");
+        if (mBannerBitmap != null) {
+            mIsBannerSet = true;
+        }
         load(mVastModel);
         openOffer();
     }

--- a/player/src/main/java/net/pubnative/player/VASTPlayer.java
+++ b/player/src/main/java/net/pubnative/player/VASTPlayer.java
@@ -166,7 +166,6 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
     private PlayerState   mPlayerState      = PlayerState.Empty;
     private List<Integer> mProgressTracker  = null;
     private double        mTargetAspect     = -1.0;
-    private boolean       mIsBannerSet      = false;
 
     public VASTPlayer(Context context) {
         super(context);
@@ -325,11 +324,6 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
         mQuartile = 0;
         mTrackingEventMap = null;
         mProgressTracker = null;
-        if (mIsBannerSet) {
-            mIsBannerSet = false;
-        } else {
-            mBannerBitmap = null;
-        }
     }
 
     private void setLoadingState() {
@@ -468,7 +462,6 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
         } else {
             mBanner.setImageBitmap(mBannerBitmap);
         }
-        mIsBannerSet = true;
     }
 
     /**
@@ -535,6 +528,7 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
      * CachingListener.onVASTPlayerCachingFinish(), so you can start video reproduction.
      *
      * @param model model containing the parsed VAST XML
+     * @deprecated Please use load(VASTModel model, Bitmap banner) instead
      */
     public void load(VASTModel model) {
 
@@ -542,9 +536,24 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
 
         // Clean, assign, load
         setState(PlayerState.Empty);
-        mVastModel = model;
-        mIsDataSourceSet = false;
-        setState(PlayerState.Loading);
+        startLoading(model);
+    }
+
+    /**
+     * Sets banner and starts loading a video VASTModel in the player, it will notify when it's
+     * ready with CachingListener.onVASTPlayerCachingFinish(), so you can start video reproduction.
+     *
+     * @param model  model containing the parsed VAST XML.
+     * @param banner valid bitmap.
+     */
+    public void load(VASTModel model, Bitmap banner) {
+
+        VASTLog.v(TAG, "load");
+
+        // Clean, assign, load
+        setState(PlayerState.Empty);
+        setBanner(banner);
+        startLoading(model);
     }
 
     /**
@@ -640,10 +649,7 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
     public void onOpenClick() {
 
         VASTLog.v(TAG, "onOpenClick");
-        if (mBannerBitmap != null) {
-            mIsBannerSet = true;
-        }
-        load(mVastModel);
+        load(mVastModel, mBannerBitmap);
         openOffer();
     }
 
@@ -965,6 +971,14 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
             invokeOnFail(exception);
             destroy();
         }
+    }
+
+    private void startLoading(VASTModel model) {
+
+        Log.v(TAG, "startLoading");
+        mVastModel = model;
+        mIsDataSourceSet = false;
+        setState(PlayerState.Loading);
     }
 
     // Event processing

--- a/player/src/main/java/net/pubnative/player/VASTPlayer.java
+++ b/player/src/main/java/net/pubnative/player/VASTPlayer.java
@@ -325,7 +325,6 @@ public class VASTPlayer extends RelativeLayout implements MediaPlayer.OnCompleti
         mQuartile = 0;
         mTrackingEventMap = null;
         mProgressTracker = null;
-        mBannerBitmap = null;
         if (mIsBannerSet) {
             mIsBannerSet = false;
         } else {


### PR DESCRIPTION
This patch includes fix for displaying banner if it's set.

Now, if banner is set, we set a `boolean` variable `mIsBannerSet` to `true` so that on load while setting state to empty we don't nullify the banner in order to display the banner. Again on open offer we do check if `mBannerBitmap` is not null, we set this variable to `true`.