### PR TITLE
[MA-217] Hotfix http url connection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,6 @@ allprojects {
     }
 }
 subprojects {
-    version = "2.0.0"
+    version = "2.0.1"
     group = "net.pubnative"
 }

--- a/player/src/main/java/net/pubnative/player/util/HttpTools.java
+++ b/player/src/main/java/net/pubnative/player/util/HttpTools.java
@@ -33,6 +33,7 @@ package net.pubnative.player.util;
 
 import android.text.TextUtils;
 
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -68,14 +69,8 @@ public class HttpTools {
                         VASTLog.w(TAG, url + ": " + e.getMessage() + ":" + e.toString());
 
                     } finally {
-
                         if (conn != null) {
-
-                            try {
-
-                                conn.disconnect();
-
-                            } catch (Exception e) {}
+                            conn.disconnect();
                         }
                     }
 

--- a/player/src/main/java/net/pubnative/player/util/HttpTools.java
+++ b/player/src/main/java/net/pubnative/player/util/HttpTools.java
@@ -33,7 +33,6 @@ package net.pubnative.player.util;
 
 import android.text.TextUtils;
 
-import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -60,6 +59,7 @@ public class HttpTools {
                         conn.setConnectTimeout(5000);
                         conn.setRequestProperty("Connection", "close");
                         conn.setRequestMethod("GET");
+                        conn.connect();
 
                         int code = conn.getResponseCode();
                         VASTLog.v(TAG, "response code:" + code + ", for URL:" + url);

--- a/player/src/main/java/net/pubnative/player/util/HttpTools.java
+++ b/player/src/main/java/net/pubnative/player/util/HttpTools.java
@@ -64,6 +64,9 @@ public class HttpTools {
                         int code = conn.getResponseCode();
                         VASTLog.v(TAG, "response code:" + code + ", for URL:" + url);
 
+                        conn.getInputStream().close();
+                        conn.getOutputStream().close();
+
                     } catch (Exception e) {
 
                         VASTLog.w(TAG, url + ": " + e.getMessage() + ":" + e.toString());


### PR DESCRIPTION
In Android, HttpUrlConnection has a very big problem with the resource allocation. Method `getResponseCode()` create a new InputStream inside and don't release it. For this, we should get the stream and close it manually.